### PR TITLE
FIX - Jira next gen issue transition changes

### DIFF
--- a/Jira/InedoExtension/Clients/JiraContext.cs
+++ b/Jira/InedoExtension/Clients/JiraContext.cs
@@ -2,11 +2,12 @@
 {
     internal sealed class JiraContext
     {
-        public JiraContext(JiraProject project, string fixForVersion, string customJql)
+        public JiraContext(JiraProject project, string fixForVersion, string customJql, string status = null)
         {
             this.Project = project ?? new JiraProject();
             this.FixForVersion = fixForVersion;
             this.CustomJql = AH.NullIf(customJql, string.Empty);
+            this.Status = AH.NullIf(status, string.Empty);
         }
 #if BuildMaster
         public JiraContext(JiraProvider provider, IssueTrackerConnectionContext c)
@@ -21,7 +22,8 @@
         public string FixForVersion { get; }
         public string ClosedState { get; }
         public string CustomJql { get; }
-        
+        public string Status { get; }
+
         public string GetJql()
         {
             if (!string.IsNullOrEmpty(this.CustomJql))
@@ -30,7 +32,8 @@
             string jql = $"project='{AH.CoalesceString(this.Project.Key, this.Project.Name)}'";
             if (!string.IsNullOrEmpty(this.FixForVersion))
                 jql += $" and fixVersion='{this.FixForVersion}'";
-
+            if (!string.IsNullOrEmpty(this.Status))
+                jql += $" and status='{this.Status}'";
             return jql;
         }
     }

--- a/Jira/InedoExtension/Operations/TransitionIssuesOperation.cs
+++ b/Jira/InedoExtension/Operations/TransitionIssuesOperation.cs
@@ -45,7 +45,6 @@ Transition-Issues(
         public string ToStatus { get; set; }
         [ScriptAlias("FixFor")]
         [DisplayName("With fix for version")]
-        [PlaceholderText("$ReleaseNumber")]
         [SuggestableValue(typeof(JiraFixForVersionSuggestionProvider))]
         public string FixForVersion { get; set; }
         [ScriptAlias("Id")]

--- a/Jira/InedoExtension/Operations/TransitionIssuesOperation.cs
+++ b/Jira/InedoExtension/Operations/TransitionIssuesOperation.cs
@@ -63,9 +63,7 @@ Transition-Issues(
             if (project == null)
                 return;
 
-            var fixForVersion = this.FixForVersion ?? (context as IStandardContext)?.SemanticVersion;
-
-            var jiraContext = new JiraContext(project, fixForVersion, null);
+            var jiraContext = new JiraContext(project, this.FixForVersion, null, FromStatus);
 
             if (this.IssueId != null)
             {


### PR DESCRIPTION
Could not transition issues in Jira next-gen projects due to JIRA Rest API throwing exception because next-gen project types do not currently have a fixVersion field.  

- Made fixVersion optional in transition operation by removing default value
- Removed fixVersion placeholder
- Added fromStatus to Jira context to allow jql filter on transition issue's fromStatus  (otherwise JQL would return all issues in next-gen project due to no fixVersion)