### PR TITLE
Revert "FIX - Jira next gen issue transition changes"

### DIFF
--- a/Jira/InedoExtension/Clients/JiraContext.cs
+++ b/Jira/InedoExtension/Clients/JiraContext.cs
@@ -2,12 +2,11 @@
 {
     internal sealed class JiraContext
     {
-        public JiraContext(JiraProject project, string fixForVersion, string customJql, string status = null)
+        public JiraContext(JiraProject project, string fixForVersion, string customJql)
         {
             this.Project = project ?? new JiraProject();
             this.FixForVersion = fixForVersion;
             this.CustomJql = AH.NullIf(customJql, string.Empty);
-            this.Status = AH.NullIf(status, string.Empty);
         }
 #if BuildMaster
         public JiraContext(JiraProvider provider, IssueTrackerConnectionContext c)
@@ -22,8 +21,7 @@
         public string FixForVersion { get; }
         public string ClosedState { get; }
         public string CustomJql { get; }
-        public string Status { get; }
-
+        
         public string GetJql()
         {
             if (!string.IsNullOrEmpty(this.CustomJql))
@@ -32,8 +30,7 @@
             string jql = $"project='{AH.CoalesceString(this.Project.Key, this.Project.Name)}'";
             if (!string.IsNullOrEmpty(this.FixForVersion))
                 jql += $" and fixVersion='{this.FixForVersion}'";
-            if (!string.IsNullOrEmpty(this.Status))
-                jql += $" and status='{this.Status}'";
+
             return jql;
         }
     }

--- a/Jira/InedoExtension/Operations/TransitionIssuesOperation.cs
+++ b/Jira/InedoExtension/Operations/TransitionIssuesOperation.cs
@@ -45,6 +45,7 @@ Transition-Issues(
         public string ToStatus { get; set; }
         [ScriptAlias("FixFor")]
         [DisplayName("With fix for version")]
+        [PlaceholderText("$ReleaseNumber")]
         [SuggestableValue(typeof(JiraFixForVersionSuggestionProvider))]
         public string FixForVersion { get; set; }
         [ScriptAlias("Id")]
@@ -63,7 +64,9 @@ Transition-Issues(
             if (project == null)
                 return;
 
-            var jiraContext = new JiraContext(project, this.FixForVersion, null, FromStatus);
+            var fixForVersion = this.FixForVersion ?? (context as IStandardContext)?.SemanticVersion;
+
+            var jiraContext = new JiraContext(project, fixForVersion, null);
 
             if (this.IssueId != null)
             {


### PR DESCRIPTION
Reverts Inedo/inedox-jira#9

Could be disruptive to multi-revision projects that depend on the default Jira fix version where they have not explicitly set the associate release version. Better solution is to add custom jql field that will override the fix for version if provided (similar to Issue field).